### PR TITLE
fix: add generics for better devex

### DIFF
--- a/pkg/ethereum/execution/types.go
+++ b/pkg/ethereum/execution/types.go
@@ -1,6 +1,7 @@
 package execution
 
 import (
+	"github.com/init4tech/signet-infra-components/pkg/utils"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -44,6 +45,8 @@ type ExecutionClientArgs struct {
 	Bootnodes pulumi.StringArray `pulumi:"bootnodes,optional"`
 	// AdditionalArgs are additional command line arguments
 	AdditionalArgs pulumi.StringArray `pulumi:"additionalArgs,optional"`
+	// Environment variables
+	ExecutionClientEnv ExecutionClientEnv `pulumi:"executionClientEnv,optional"`
 }
 
 // ExecutionClientComponent represents an execution client deployment
@@ -66,4 +69,15 @@ type ExecutionClientComponent struct {
 	RPCService *corev1.Service
 	// StatefulSet is the stateful set
 	StatefulSet *appsv1.StatefulSet
+}
+
+// ExecutionClientEnv contains environment variables for the execution client
+type ExecutionClientEnv struct {
+	// Add any environment variables needed by the execution client
+	RustLog pulumi.StringInput `pulumi:"rustLog"`
+}
+
+// GetEnvMap implements the utils.EnvProvider interface
+func (e ExecutionClientEnv) GetEnvMap() pulumi.StringMap {
+	return utils.CreateEnvMap(e)
 }

--- a/pkg/quincey/quincey.go
+++ b/pkg/quincey/quincey.go
@@ -140,7 +140,7 @@ func createDeployment(ctx *pulumi.Context, args *QuinceyComponentArgs, parent *Q
 func createConfigMap(ctx *pulumi.Context, args *QuinceyComponentArgs, parent *QuinceyComponent) (*corev1.ConfigMap, error) {
 	labels := utils.CreateResourceLabels(ComponentName, ServiceName, DefaultAppSelector, nil)
 
-	return utils.CreateConfigMap(ctx, ServiceName, args.Namespace, labels, args.Env)
+	return utils.CreateConfigMap(ctx, ServiceName, args.Namespace, labels, &args.Env)
 }
 
 // createContainer creates the container specification for the Quincey service

--- a/pkg/signet_node/signet_node.go
+++ b/pkg/signet_node/signet_node.go
@@ -292,8 +292,8 @@ func NewSignetNode(ctx *pulumi.Context, args SignetNodeComponentArgs, opts ...pu
 	}
 
 	// Create ConfigMap for consensus environment variables
-	consensusEnv := map[string]pulumi.StringInput{
-		"EXAMPLE": pulumi.String("example"),
+	consensusEnv := ConsensusEnv{
+		Example: pulumi.String("example"),
 	}
 
 	consensusConfigMapName := "consensus-configmap-env-config"

--- a/pkg/signet_node/types.go
+++ b/pkg/signet_node/types.go
@@ -75,6 +75,16 @@ func (e SignetNodeEnv) GetEnvMap() pulumi.StringMap {
 	return utils.CreateEnvMap(e)
 }
 
+// ConsensusEnv contains environment variables for the consensus client
+type ConsensusEnv struct {
+	Example pulumi.StringInput `pulumi:"example"`
+}
+
+// GetEnvMap implements the utils.EnvProvider interface
+func (e ConsensusEnv) GetEnvMap() pulumi.StringMap {
+	return utils.CreateEnvMap(e)
+}
+
 // SignetNode interface defines methods that the SignetNodeComponent must implement
 type SignetNode interface {
 }


### PR DESCRIPTION
Adding generics around Env creation for more restrictive arg types that can be checked at compile time
