### PR TITLE
feat: add args for custom volume mount paths

### DIFF
--- a/pkg/signet_node/constants.go
+++ b/pkg/signet_node/constants.go
@@ -29,6 +29,11 @@ const (
 
 	// Component name
 	ComponentKind = "the-builder:index:SignetNode"
+	
+	// Default mount paths for volumes
+	DefaultSignetNodeDataMountPath = "/root/.local/share/reth"
+	DefaultRollupDataMountPath     = "/root/.local/share/exex"
+	DefaultExecutionJwtMountPath   = "/etc/reth/execution-jwt"
 )
 
 // Resource name suffixes

--- a/pkg/signet_node/signet_node.go
+++ b/pkg/signet_node/signet_node.go
@@ -12,6 +12,9 @@ import (
 )
 
 func NewSignetNode(ctx *pulumi.Context, args SignetNodeComponentArgs, opts ...pulumi.ResourceOption) (*SignetNodeComponent, error) {
+	// Apply defaults before validation
+	args.ApplyDefaults()
+	
 	if err := args.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid signet node component args: %w", err)
 	}
@@ -205,15 +208,15 @@ func NewSignetNode(ctx *pulumi.Context, args SignetNodeComponentArgs, opts ...pu
 							VolumeMounts: corev1.VolumeMountArray{
 								corev1.VolumeMountArgs{
 									Name:      pulumi.String("signet-node-data"),
-									MountPath: pulumi.String("/root/.local/share/reth"),
+									MountPath: internalArgs.SignetNodeDataMountPath,
 								},
 								corev1.VolumeMountArgs{
 									Name:      pulumi.String("rollup-data"),
-									MountPath: pulumi.String("/root/.local/share/exex"),
+									MountPath: internalArgs.RollupDataMountPath,
 								},
 								corev1.VolumeMountArgs{
 									Name:      pulumi.String("execution-jwt"),
-									MountPath: pulumi.String("/etc/reth/execution-jwt"),
+									MountPath: internalArgs.ExecutionJwtMountPath,
 								},
 							},
 							Resources: NewResourceRequirements("2", "16Gi", "2", "4Gi"),

--- a/pkg/signet_node/types.go
+++ b/pkg/signet_node/types.go
@@ -29,6 +29,9 @@ type SignetNodeComponentArgs struct {
 	ExecutionClientStartCommand []string
 	ConsensusClientStartCommand []string
 	AppLabels                   AppLabels
+	SignetNodeDataMountPath     string // Optional: defaults to "/root/.local/share/reth"
+	RollupDataMountPath         string // Optional: defaults to "/root/.local/share/exex"
+	ExecutionJwtMountPath       string // Optional: defaults to "/etc/reth/execution-jwt"
 }
 
 // Internal structs with Pulumi types for use within the component
@@ -45,6 +48,9 @@ type signetNodeComponentArgsInternal struct {
 	ExecutionClientStartCommand pulumi.StringArrayInput
 	ConsensusClientStartCommand pulumi.StringArrayInput
 	AppLabels                   AppLabels
+	SignetNodeDataMountPath     pulumi.StringInput
+	RollupDataMountPath         pulumi.StringInput
+	ExecutionJwtMountPath       pulumi.StringInput
 }
 
 type SignetNodeComponent struct {
@@ -132,6 +138,9 @@ func (args SignetNodeComponentArgs) toInternal() signetNodeComponentArgsInternal
 		ExecutionClientStartCommand: pulumi.ToStringArray(args.ExecutionClientStartCommand),
 		ConsensusClientStartCommand: pulumi.ToStringArray(args.ConsensusClientStartCommand),
 		AppLabels:                   args.AppLabels,
+		SignetNodeDataMountPath:     pulumi.String(args.SignetNodeDataMountPath),
+		RollupDataMountPath:         pulumi.String(args.RollupDataMountPath),
+		ExecutionJwtMountPath:       pulumi.String(args.ExecutionJwtMountPath),
 	}
 }
 

--- a/pkg/signet_node/validation.go
+++ b/pkg/signet_node/validation.go
@@ -4,6 +4,19 @@ import (
 	"fmt"
 )
 
+// ApplyDefaults sets default values for optional fields
+func (args *SignetNodeComponentArgs) ApplyDefaults() {
+	if args.SignetNodeDataMountPath == "" {
+		args.SignetNodeDataMountPath = DefaultSignetNodeDataMountPath
+	}
+	if args.RollupDataMountPath == "" {
+		args.RollupDataMountPath = DefaultRollupDataMountPath
+	}
+	if args.ExecutionJwtMountPath == "" {
+		args.ExecutionJwtMountPath = DefaultExecutionJwtMountPath
+	}
+}
+
 func (args *SignetNodeComponentArgs) Validate() error {
 	if args.Name == "" {
 		return fmt.Errorf("name is required")

--- a/pkg/signet_node/validation_test.go
+++ b/pkg/signet_node/validation_test.go
@@ -141,3 +141,35 @@ func TestSignetNodeComponentArgsValidate(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "execution pvc size is required")
 }
+
+func TestApplyDefaults(t *testing.T) {
+	// Test with no mount paths specified
+	args := SignetNodeComponentArgs{}
+	args.ApplyDefaults()
+	
+	assert.Equal(t, DefaultSignetNodeDataMountPath, args.SignetNodeDataMountPath)
+	assert.Equal(t, DefaultRollupDataMountPath, args.RollupDataMountPath)
+	assert.Equal(t, DefaultExecutionJwtMountPath, args.ExecutionJwtMountPath)
+	
+	// Test with custom mount paths
+	customArgs := SignetNodeComponentArgs{
+		SignetNodeDataMountPath: "/custom/signet/data",
+		RollupDataMountPath:     "/custom/rollup/data",
+		ExecutionJwtMountPath:   "/custom/jwt",
+	}
+	customArgs.ApplyDefaults()
+	
+	assert.Equal(t, "/custom/signet/data", customArgs.SignetNodeDataMountPath)
+	assert.Equal(t, "/custom/rollup/data", customArgs.RollupDataMountPath)
+	assert.Equal(t, "/custom/jwt", customArgs.ExecutionJwtMountPath)
+	
+	// Test with partial custom mount paths
+	partialArgs := SignetNodeComponentArgs{
+		SignetNodeDataMountPath: "/custom/signet/data",
+	}
+	partialArgs.ApplyDefaults()
+	
+	assert.Equal(t, "/custom/signet/data", partialArgs.SignetNodeDataMountPath)
+	assert.Equal(t, DefaultRollupDataMountPath, partialArgs.RollupDataMountPath)
+	assert.Equal(t, DefaultExecutionJwtMountPath, partialArgs.ExecutionJwtMountPath)
+}


### PR DESCRIPTION
  1. Added three optional fields to SignetNodeComponentArgs in types.go:
    - SignetNodeDataMountPath (defaults to /root/.local/share/reth)
    - RollupDataMountPath (defaults to /root/.local/share/exex)
    - ExecutionJwtMountPath (defaults to /etc/reth/execution-jwt)
  2. Created default constants in constants.go for the default mount paths
  3. Added ApplyDefaults() method in validation.go that sets default values if not provided
  4. Updated internal types to include the new mount path fields
  5. Modified the conversion function toInternal() to include the new fields
  6. Updated NewSignetNode() in signet_node.go to:
    - Call ApplyDefaults() before validation
    - Use the configurable mount paths instead of hardcoded values
  7. Added comprehensive tests for the new functionality
